### PR TITLE
允许域名指向局域网IP

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -3,7 +3,7 @@ config dnsmasq
 	option boguspriv	1
 	option filterwin2k	0  # enable for dial on demand
 	option localise_queries	1
-	option rebind_protection 1  # disable if upstream must serve RFC1918 addresses
+	option rebind_protection 0  # disable if upstream must serve RFC1918 addresses
 	option rebind_localhost 1  # enable for RBL checking and similar services
 	#list rebind_domain example.lan  # whitelist RFC1918 responses for domains
 	option local	'/lan/'


### PR DESCRIPTION
局域网IP
10.0.0.0 - 10.255.255.255 (10/8比特前缀)
172.16.0.0 - 172.31.255.255 (172.16/12比特前缀)
192.168.0.0 - 192.168.255.255 (192.168/16比特前缀)
