### PR TITLE
合入qsdk更新的小版本3.0.490.256

### DIFF
--- a/package/network/services/hostapd/patches/b00-004-hostapd-Avoid-key-reinstallation-in-FT-handshake.patch
+++ b/package/network/services/hostapd/patches/b00-004-hostapd-Avoid-key-reinstallation-in-FT-handshake.patch
@@ -1,0 +1,148 @@
+From 8424dcecf9031fcb658cfe08815e4f2dde0c6e0c Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 15:58:35 +0800
+Subject: [PATCH 1/8] hostapd: Avoid key reinstallation in FT handshake
+
+Do not reinstall TK to the driver during Reassociation Response frame
+processing if the first attempt of setting the TK succeeded. This avoids
+issues related to clearing the TX/RX PN that could result in reusing
+same PN values for transmitted frames (e.g., due to CCM nonce reuse and
+also hitting replay protection on the receiver) and accepting replayed
+frames on RX side.
+
+This issue was introduced by the commit
+0e84c25434e6a1f283c7b4e62e483729085b78d2 ('FT: Fix PTK configuration in
+authenticator') which allowed wpa_ft_install_ptk() to be called multiple
+times with the same PTK. While the second configuration attempt is
+needed with some drivers, it must be done only if the first attempt
+failed.
+
+Signed-off-by: Mathy Vanhoef <Mathy.Vanhoef@cs.kuleuven.be>
+---
+ src/ap/ieee802_11.c  | 10 +++++++++-
+ src/ap/wpa_auth.c    |  9 +++++++++
+ src/ap/wpa_auth.h    |  3 ++-
+ src/ap/wpa_auth_ft.c | 10 ++++++++++
+ src/ap/wpa_auth_i.h  |  1 +
+ 5 files changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/src/ap/ieee802_11.c b/src/ap/ieee802_11.c
+index 35a0deb..c1b7710 100644
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -2566,8 +2566,16 @@ static void handle_assoc_cb(struct hostapd_data *hapd,
+ 	 * Remove the STA entry in order to make sure the STA PS state gets
+ 	 * cleared and configuration gets updated in case of reassociation back
+ 	 * to the same AP.
++	 *
++	 * Skip this if the STA has already completed FT reassociation and the
++	 * TK has been configured since the TX/RX PN must not be reset to 0 for
++	 * the same key.
+ 	 */
+-	hostapd_drv_sta_remove(hapd, sta->addr);
++	if (!(sta->flags & WLAN_STA_AUTHORIZED) ||
++	     !wpa_auth_sta_ft_tk_already_set(sta->wpa_sm)) {
++		hostapd_drv_sta_remove(hapd, sta->addr);
++		wpa_auth_sm_event(sta->wpa_sm, WPA_DRV_STA_REMOVED);
++	}
+ 
+ #ifdef CONFIG_IEEE80211N
+ 	if (sta->flags & WLAN_STA_HT)
+diff --git a/src/ap/wpa_auth.c b/src/ap/wpa_auth.c
+index 34d27bb..4692ce1 100644
+--- a/src/ap/wpa_auth.c
++++ b/src/ap/wpa_auth.c
+@@ -1740,6 +1740,9 @@ int wpa_auth_sm_event(struct wpa_state_machine *sm, enum wpa_event event)
+ #else /* CONFIG_IEEE80211R */
+ 		break;
+ #endif /* CONFIG_IEEE80211R */
++	case WPA_DRV_STA_REMOVED:
++		sm->tk_already_set = FALSE;
++		return 0;
+ 	}
+ 
+ #ifdef CONFIG_IEEE80211R
+@@ -3209,6 +3212,12 @@ int wpa_auth_sta_wpa_version(struct wpa_state_machine *sm)
+ 	return sm->wpa;
+ }
+ 
++int wpa_auth_sta_ft_tk_already_set(struct wpa_state_machine *sm)
++{
++	if (!sm || !wpa_key_mgmt_ft(sm->wpa_key_mgmt))
++		return 0;
++	return sm->tk_already_set;
++}
+ 
+ int wpa_auth_sta_clear_pmksa(struct wpa_state_machine *sm,
+ 			     struct rsn_pmksa_cache_entry *entry)
+diff --git a/src/ap/wpa_auth.h b/src/ap/wpa_auth.h
+index fd04f16..3e53461 100644
+--- a/src/ap/wpa_auth.h
++++ b/src/ap/wpa_auth.h
+@@ -258,7 +258,7 @@ void wpa_receive(struct wpa_authenticator *wpa_auth,
+ 		 u8 *data, size_t data_len);
+ enum wpa_event {
+ 	WPA_AUTH, WPA_ASSOC, WPA_DISASSOC, WPA_DEAUTH, WPA_REAUTH,
+-	WPA_REAUTH_EAPOL, WPA_ASSOC_FT
++	WPA_REAUTH_EAPOL, WPA_ASSOC_FT, WPA_DRV_STA_REMOVED
+ };
+ void wpa_remove_ptk(struct wpa_state_machine *sm);
+ int wpa_auth_sm_event(struct wpa_state_machine *sm, enum wpa_event event);
+@@ -271,6 +271,7 @@ int wpa_auth_pairwise_set(struct wpa_state_machine *sm);
+ int wpa_auth_get_pairwise(struct wpa_state_machine *sm);
+ int wpa_auth_sta_key_mgmt(struct wpa_state_machine *sm);
+ int wpa_auth_sta_wpa_version(struct wpa_state_machine *sm);
++int wpa_auth_sta_ft_tk_already_set(struct wpa_state_machine *sm);
+ int wpa_auth_sta_clear_pmksa(struct wpa_state_machine *sm,
+ 			     struct rsn_pmksa_cache_entry *entry);
+ struct rsn_pmksa_cache_entry *
+diff --git a/src/ap/wpa_auth_ft.c b/src/ap/wpa_auth_ft.c
+index eeaffbf..f8f5dbe 100644
+--- a/src/ap/wpa_auth_ft.c
++++ b/src/ap/wpa_auth_ft.c
+@@ -780,6 +780,14 @@ void wpa_ft_install_ptk(struct wpa_state_machine *sm)
+ 		return;
+ 	}
+ 
++	if (sm->tk_already_set) {
++		/* Must avoid TK reconfiguration to prevent clearing of TX/RX
++		 * PN in the driver */
++		wpa_printf(MSG_DEBUG,
++			   "FT: Do not re-install same PTK to the driver");
++		return;
++	}
++
+ 	/* FIX: add STA entry to kernel/driver here? The set_key will fail
+ 	 * most likely without this.. At the moment, STA entry is added only
+ 	 * after association has been completed. This function will be called
+@@ -792,6 +800,7 @@ void wpa_ft_install_ptk(struct wpa_state_machine *sm)
+ 
+ 	/* FIX: MLME-SetProtection.Request(TA, Tx_Rx) */
+ 	sm->pairwise_set = TRUE;
++	sm->tk_already_set = TRUE;
+ }
+ 
+ 
+@@ -898,6 +907,7 @@ static int wpa_ft_process_auth_req(struct wpa_state_machine *sm,
+ 
+ 	sm->pairwise = pairwise;
+ 	sm->PTK_valid = TRUE;
++	sm->tk_already_set = FALSE;
+ 	wpa_ft_install_ptk(sm);
+ 
+ 	buflen = 2 + sizeof(struct rsn_mdie) + 2 + sizeof(struct rsn_ftie) +
+diff --git a/src/ap/wpa_auth_i.h b/src/ap/wpa_auth_i.h
+index 57b098f..234d84c 100644
+--- a/src/ap/wpa_auth_i.h
++++ b/src/ap/wpa_auth_i.h
+@@ -64,6 +64,7 @@ struct wpa_state_machine {
+ 	struct wpa_ptk PTK;
+ 	Boolean PTK_valid;
+ 	Boolean pairwise_set;
++	Boolean tk_already_set;
+ 	int keycount;
+ 	Boolean Pair;
+ 	struct wpa_key_replay_counter {
+-- 
+1.9.1
+

--- a/package/network/services/hostapd/patches/b00-005-Prevent-reinstallation-of-an-already-in-use-group-ke.patch
+++ b/package/network/services/hostapd/patches/b00-005-Prevent-reinstallation-of-an-already-in-use-group-ke.patch
@@ -1,0 +1,251 @@
+From 23857e0921f8ff398348ce1082c1c8896a31afd3 Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 16:22:18 +0800
+Subject: [PATCH 2/8] Prevent reinstallation of an already in-use group key
+
+Track the current GTK and IGTK that is in use and when receiving a
+(possibly retransmitted) Group Message 1 or WNM-Sleep Mode Response, do
+not install the given key if it is already in use. This prevents an
+attacker from trying to trick the client into resetting or lowering the
+sequence counter associated to the group key.
+
+Signed-off-by: Mathy Vanhoef <Mathy.Vanhoef@cs.kuleuven.be>
+---
+ src/common/wpa_common.h |  11 +++++
+ src/rsn_supp/wpa.c      | 118 +++++++++++++++++++++++++++++-------------------
+ src/rsn_supp/wpa_i.h    |   4 ++
+ 3 files changed, 87 insertions(+), 46 deletions(-)
+
+diff --git a/src/common/wpa_common.h b/src/common/wpa_common.h
+index c08f651..542abda 100644
+--- a/src/common/wpa_common.h
++++ b/src/common/wpa_common.h
+@@ -215,7 +215,18 @@ struct wpa_ptk {
+ 	size_t tk_len;
+ };
+ 
++struct wpa_gtk {
++	u8 gtk[WPA_GTK_MAX_LEN];
++	size_t gtk_len;
++};
+ 
++#ifdef CONFIG_IEEE80211W
++struct wpa_igtk {
++	u8 igtk[WPA_IGTK_MAX_LEN];
++	size_t igtk_len;
++};
++#endif /* CONFIG_IEEE80211W */
++ 
+ /* WPA IE version 1
+  * 00-50-f2:1 (OUI:OUI type)
+  * 0x01 0x00 (version; little endian)
+diff --git a/src/rsn_supp/wpa.c b/src/rsn_supp/wpa.c
+index 97fedd5..4314df8 100644
+--- a/src/rsn_supp/wpa.c
++++ b/src/rsn_supp/wpa.c
+@@ -697,6 +697,15 @@ static int wpa_supplicant_install_gtk(struct wpa_sm *sm,
+ 	const u8 *_gtk = gd->gtk;
+ 	u8 gtk_buf[32];
+ 
++	/* Detect possible key reinstallation */
++	if (sm->gtk.gtk_len == (size_t) gd->gtk_len &&
++	    os_memcmp(sm->gtk.gtk, gd->gtk, sm->gtk.gtk_len) == 0) {
++		wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
++			"WPA: Not reinstalling already in-use GTK to the driver (keyidx=%d tx=%d len=%d)",
++			gd->keyidx, gd->tx, gd->gtk_len);
++		return 0;
++	}
++
+ 	wpa_hexdump_key(MSG_DEBUG, "WPA: Group Key", gd->gtk, gd->gtk_len);
+ 	wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
+ 		"WPA: Installing GTK to the driver (keyidx=%d tx=%d len=%d)",
+@@ -731,6 +740,9 @@ static int wpa_supplicant_install_gtk(struct wpa_sm *sm,
+ 	}
+ 	os_memset(gtk_buf, 0, sizeof(gtk_buf));
+ 
++	sm->gtk.gtk_len = gd->gtk_len;
++	os_memcpy(sm->gtk.gtk, gd->gtk, sm->gtk.gtk_len);
++
+ 	return 0;
+ }
+ 
+@@ -801,6 +813,46 @@ static int wpa_supplicant_pairwise_gtk(struct wpa_sm *sm,
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_IEEE80211W
++static int wpa_supplicant_install_igtk(struct wpa_sm *sm,
++				       const struct wpa_igtk_kde *igtk)
++{
++	size_t len = wpa_cipher_key_len(sm->mgmt_group_cipher);
++	u16 keyidx = WPA_GET_LE16(igtk->keyid);
++
++	/* Detect possible key reinstallation */
++	if (sm->igtk.igtk_len == len &&
++	    os_memcmp(sm->igtk.igtk, igtk->igtk, sm->igtk.igtk_len) == 0) {
++		wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
++			"WPA: Not reinstalling already in-use IGTK to the driver (keyidx=%d)",
++			keyidx);
++		return  0;
++	}
++
++	wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
++		"WPA: IGTK keyid %d pn %02x%02x%02x%02x%02x%02x",
++		keyidx, MAC2STR(igtk->pn));
++	wpa_hexdump_key(MSG_DEBUG, "WPA: IGTK", igtk->igtk, len);
++	if (keyidx > 4095) {
++		wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
++			"WPA: Invalid IGTK KeyID %d", keyidx);
++		return -1;
++	}
++	if (wpa_sm_set_key(sm, wpa_cipher_to_alg(sm->mgmt_group_cipher),
++			   broadcast_ether_addr,
++			   keyidx, 0, igtk->pn, sizeof(igtk->pn),
++			   igtk->igtk, len) < 0) {
++		wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
++			"WPA: Failed to configure IGTK to the driver");
++		return -1;
++	}
++
++	sm->igtk.igtk_len = len;
++	os_memcpy(sm->igtk.igtk, igtk->igtk, sm->igtk.igtk_len);
++
++	return 0;
++}
++#endif /* CONFIG_IEEE80211W */
+ 
+ static int ieee80211w_set_keys(struct wpa_sm *sm,
+ 			       struct wpa_eapol_ie_parse *ie)
+@@ -812,30 +864,14 @@ static int ieee80211w_set_keys(struct wpa_sm *sm,
+ 	if (ie->igtk) {
+ 		size_t len;
+ 		const struct wpa_igtk_kde *igtk;
+-		u16 keyidx;
++
+ 		len = wpa_cipher_key_len(sm->mgmt_group_cipher);
+ 		if (ie->igtk_len != WPA_IGTK_KDE_PREFIX_LEN + len)
+ 			return -1;
++
+ 		igtk = (const struct wpa_igtk_kde *) ie->igtk;
+-		keyidx = WPA_GET_LE16(igtk->keyid);
+-		wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG, "WPA: IGTK keyid %d "
+-			"pn %02x%02x%02x%02x%02x%02x",
+-			keyidx, MAC2STR(igtk->pn));
+-		wpa_hexdump_key(MSG_DEBUG, "WPA: IGTK",
+-				igtk->igtk, len);
+-		if (keyidx > 4095) {
+-			wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
+-				"WPA: Invalid IGTK KeyID %d", keyidx);
+-			return -1;
+-		}
+-		if (wpa_sm_set_key(sm, wpa_cipher_to_alg(sm->mgmt_group_cipher),
+-				   broadcast_ether_addr,
+-				   keyidx, 0, igtk->pn, sizeof(igtk->pn),
+-				   igtk->igtk, len) < 0) {
+-			wpa_msg(sm->ctx->msg_ctx, MSG_WARNING,
+-				"WPA: Failed to configure IGTK to the driver");
+-			return -1;
+-		}
++		if (wpa_supplicant_install_igtk(sm, igtk) < 0)
++ 			return -1;
+ 	}
+ 
+ 	return 0;
+@@ -2254,7 +2290,7 @@ void wpa_sm_deinit(struct wpa_sm *sm)
+  */
+ void wpa_sm_notify_assoc(struct wpa_sm *sm, const u8 *bssid)
+ {
+-	int clear_ptk = 1;
++	int clear_keys = 1;
+ 
+ 	if (sm == NULL)
+ 		return;
+@@ -2280,11 +2316,11 @@ void wpa_sm_notify_assoc(struct wpa_sm *sm, const u8 *bssid)
+ 		/* Prepare for the next transition */
+ 		wpa_ft_prepare_auth_request(sm, NULL);
+ 
+-		clear_ptk = 0;
++		clear_keys = 0;
+ 	}
+ #endif /* CONFIG_IEEE80211R */
+ 
+-	if (clear_ptk) {
++	if (clear_keys) {
+ 		/*
+ 		 * IEEE 802.11, 8.4.10: Delete PTK SA on (re)association if
+ 		 * this is not part of a Fast BSS Transition.
+@@ -2294,6 +2330,10 @@ void wpa_sm_notify_assoc(struct wpa_sm *sm, const u8 *bssid)
+ 		os_memset(&sm->ptk, 0, sizeof(sm->ptk));
+ 		sm->tptk_set = 0;
+ 		os_memset(&sm->tptk, 0, sizeof(sm->tptk));
++		os_memset(&sm->gtk, 0, sizeof(sm->gtk));
++#ifdef CONFIG_IEEE80211W
++		os_memset(&sm->igtk, 0, sizeof(sm->igtk));
++#endif /* CONFIG_IEEE80211W */
+ 	}
+ 
+ #ifdef CONFIG_TDLS
+@@ -2810,6 +2850,10 @@ void wpa_sm_drop_sa(struct wpa_sm *sm)
+ 	os_memset(sm->pmk, 0, sizeof(sm->pmk));
+ 	os_memset(&sm->ptk, 0, sizeof(sm->ptk));
+ 	os_memset(&sm->tptk, 0, sizeof(sm->tptk));
++	os_memset(&sm->gtk, 0, sizeof(sm->gtk));
++#ifdef CONFIG_IEEE80211W
++	os_memset(&sm->igtk, 0, sizeof(sm->igtk));
++#endif /* CONFIG_IEEE80211W */
+ #ifdef CONFIG_IEEE80211R
+ 	os_memset(sm->xxkey, 0, sizeof(sm->xxkey));
+ 	os_memset(sm->pmk_r0, 0, sizeof(sm->pmk_r0));
+@@ -2882,29 +2926,11 @@ int wpa_wnmsleep_install_key(struct wpa_sm *sm, u8 subelem_id, u8 *buf)
+ 		os_memset(&gd, 0, sizeof(gd));
+ #ifdef CONFIG_IEEE80211W
+ 	} else if (subelem_id == WNM_SLEEP_SUBELEM_IGTK) {
+-		struct wpa_igtk_kde igd;
+-		u16 keyidx;
+-
+-		os_memset(&igd, 0, sizeof(igd));
+-		keylen = wpa_cipher_key_len(sm->mgmt_group_cipher);
+-		os_memcpy(igd.keyid, buf + 2, 2);
+-		os_memcpy(igd.pn, buf + 4, 6);
+-
+-		keyidx = WPA_GET_LE16(igd.keyid);
+-		os_memcpy(igd.igtk, buf + 10, keylen);
+-
+-		wpa_hexdump_key(MSG_DEBUG, "Install IGTK (WNM SLEEP)",
+-				igd.igtk, keylen);
+-		if (wpa_sm_set_key(sm, wpa_cipher_to_alg(sm->mgmt_group_cipher),
+-				   broadcast_ether_addr,
+-				   keyidx, 0, igd.pn, sizeof(igd.pn),
+-				   igd.igtk, keylen) < 0) {
+-			wpa_printf(MSG_DEBUG, "Failed to install the IGTK in "
+-				   "WNM mode");
+-			os_memset(&igd, 0, sizeof(igd));
+-			return -1;
+-		}
+-		os_memset(&igd, 0, sizeof(igd));
++		const struct wpa_igtk_kde *igtk;
++
++		igtk = (const struct wpa_igtk_kde *) (buf + 2);
++		if (wpa_supplicant_install_igtk(sm, igtk) < 0)
++ 			return -1;
+ #endif /* CONFIG_IEEE80211W */
+ 	} else {
+ 		wpa_printf(MSG_DEBUG, "Unknown element id");
+diff --git a/src/rsn_supp/wpa_i.h b/src/rsn_supp/wpa_i.h
+index 965a9c1..27b6123 100644
+--- a/src/rsn_supp/wpa_i.h
++++ b/src/rsn_supp/wpa_i.h
+@@ -30,6 +30,10 @@ struct wpa_sm {
+ 	u8 rx_replay_counter[WPA_REPLAY_COUNTER_LEN];
+ 	int rx_replay_counter_set;
+ 	u8 request_counter[WPA_REPLAY_COUNTER_LEN];
++	struct wpa_gtk gtk;
++#ifdef CONFIG_IEEE80211W
++	struct wpa_igtk igtk;
++#endif /* CONFIG_IEEE80211W */
+ 
+ 	struct eapol_sm *eapol; /* EAPOL state machine from upper level code */
+ 
+-- 
+1.9.1
+

--- a/package/network/services/hostapd/patches/b00-006-Extend-protection-of-GTK-IGTK-reinstallation-of-WNM-.patch
+++ b/package/network/services/hostapd/patches/b00-006-Extend-protection-of-GTK-IGTK-reinstallation-of-WNM-.patch
@@ -1,0 +1,185 @@
+From 67495a32f9c3844dae4e86e3908d0f2383586f7d Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 16:37:13 +0800
+Subject: [PATCH 3/8] Extend protection of GTK/IGTK reinstallation of WNM-Sleep
+
+This extends the protection to track last configured GTK/IGTK value
+separately from EAPOL-Key frames and WNM-Sleep Mode frames to cover a
+corner case where these two different mechanisms may get used when the
+GTK/IGTK has changed and tracking a single value is not sufficient to
+detect a possible key reconfiguration.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/rsn_supp/wpa.c   | 55 +++++++++++++++++++++++++++++++++++++---------------
+ src/rsn_supp/wpa_i.h |  2 ++
+ 2 files changed, 41 insertions(+), 16 deletions(-)
+
+diff --git a/src/rsn_supp/wpa.c b/src/rsn_supp/wpa.c
+index 4314df8..562b869 100644
+--- a/src/rsn_supp/wpa.c
++++ b/src/rsn_supp/wpa.c
+@@ -692,14 +692,17 @@ struct wpa_gtk_data {
+ 
+ static int wpa_supplicant_install_gtk(struct wpa_sm *sm,
+ 				      const struct wpa_gtk_data *gd,
+-				      const u8 *key_rsc)
++				      const u8 *key_rsc, int wnm_sleep)
+ {
+ 	const u8 *_gtk = gd->gtk;
+ 	u8 gtk_buf[32];
+ 
+ 	/* Detect possible key reinstallation */
+-	if (sm->gtk.gtk_len == (size_t) gd->gtk_len &&
+-	    os_memcmp(sm->gtk.gtk, gd->gtk, sm->gtk.gtk_len) == 0) {
++	if ((sm->gtk.gtk_len == (size_t) gd->gtk_len &&
++	     os_memcmp(sm->gtk.gtk, gd->gtk, sm->gtk.gtk_len) == 0) ||
++	    (sm->gtk_wnm_sleep.gtk_len == (size_t) gd->gtk_len &&
++	     os_memcmp(sm->gtk_wnm_sleep.gtk, gd->gtk,
++		       sm->gtk_wnm_sleep.gtk_len) == 0)) {
+ 		wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
+ 			"WPA: Not reinstalling already in-use GTK to the driver (keyidx=%d tx=%d len=%d)",
+ 			gd->keyidx, gd->tx, gd->gtk_len);
+@@ -740,9 +743,15 @@ static int wpa_supplicant_install_gtk(struct wpa_sm *sm,
+ 	}
+ 	os_memset(gtk_buf, 0, sizeof(gtk_buf));
+ 
+-	sm->gtk.gtk_len = gd->gtk_len;
+-	os_memcpy(sm->gtk.gtk, gd->gtk, sm->gtk.gtk_len);
+-
++	if (wnm_sleep) {
++		sm->gtk_wnm_sleep.gtk_len = gd->gtk_len;
++		os_memcpy(sm->gtk_wnm_sleep.gtk, gd->gtk,
++			  sm->gtk_wnm_sleep.gtk_len);
++	} else {
++		sm->gtk.gtk_len = gd->gtk_len;
++		os_memcpy(sm->gtk.gtk, gd->gtk, sm->gtk.gtk_len);
++	}
++ 
+ 	return 0;
+ }
+ 
+@@ -800,7 +809,7 @@ static int wpa_supplicant_pairwise_gtk(struct wpa_sm *sm,
+ 	    (wpa_supplicant_check_group_cipher(sm, sm->group_cipher,
+ 					       gtk_len, gtk_len,
+ 					       &gd.key_rsc_len, &gd.alg) ||
+-	     wpa_supplicant_install_gtk(sm, &gd, key->key_rsc))) {
++	     wpa_supplicant_install_gtk(sm, &gd, key->key_rsc, 0))) {
+ 		wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
+ 			"RSN: Failed to install GTK");
+ 		os_memset(&gd, 0, sizeof(gd));
+@@ -815,14 +824,18 @@ static int wpa_supplicant_pairwise_gtk(struct wpa_sm *sm,
+ 
+ #ifdef CONFIG_IEEE80211W
+ static int wpa_supplicant_install_igtk(struct wpa_sm *sm,
+-				       const struct wpa_igtk_kde *igtk)
++				       const struct wpa_igtk_kde *igtk,
++				       int wnm_sleep)
+ {
+ 	size_t len = wpa_cipher_key_len(sm->mgmt_group_cipher);
+ 	u16 keyidx = WPA_GET_LE16(igtk->keyid);
+ 
+ 	/* Detect possible key reinstallation */
+-	if (sm->igtk.igtk_len == len &&
+-	    os_memcmp(sm->igtk.igtk, igtk->igtk, sm->igtk.igtk_len) == 0) {
++	if ((sm->igtk.igtk_len == len &&
++	     os_memcmp(sm->igtk.igtk, igtk->igtk, sm->igtk.igtk_len) == 0) ||
++	    (sm->igtk_wnm_sleep.igtk_len == len &&
++	     os_memcmp(sm->igtk_wnm_sleep.igtk, igtk->igtk,
++		       sm->igtk_wnm_sleep.igtk_len) == 0)) {
+ 		wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
+ 			"WPA: Not reinstalling already in-use IGTK to the driver (keyidx=%d)",
+ 			keyidx);
+@@ -847,8 +860,14 @@ static int wpa_supplicant_install_igtk(struct wpa_sm *sm,
+ 		return -1;
+ 	}
+ 
+-	sm->igtk.igtk_len = len;
+-	os_memcpy(sm->igtk.igtk, igtk->igtk, sm->igtk.igtk_len);
++	if (wnm_sleep) {
++		sm->igtk_wnm_sleep.igtk_len = len;
++		os_memcpy(sm->igtk_wnm_sleep.igtk, igtk->igtk,
++			  sm->igtk_wnm_sleep.igtk_len);
++	} else {
++		sm->igtk.igtk_len = len;
++		os_memcpy(sm->igtk.igtk, igtk->igtk, sm->igtk.igtk_len);
++	}
+ 
+ 	return 0;
+ }
+@@ -870,7 +889,7 @@ static int ieee80211w_set_keys(struct wpa_sm *sm,
+ 			return -1;
+ 
+ 		igtk = (const struct wpa_igtk_kde *) ie->igtk;
+-		if (wpa_supplicant_install_igtk(sm, igtk) < 0)
++		if (wpa_supplicant_install_igtk(sm, igtk, 0) < 0)
+  			return -1;
+ 	}
+ 
+@@ -1519,7 +1538,7 @@ static void wpa_supplicant_process_1_of_2(struct wpa_sm *sm,
+ 	if (ret)
+ 		goto failed;
+ 
+-	if (wpa_supplicant_install_gtk(sm, &gd, key->key_rsc) ||
++	if (wpa_supplicant_install_gtk(sm, &gd, key->key_rsc, 0) ||
+ 	    wpa_supplicant_send_2_of_2(sm, key, ver, key_info))
+ 		goto failed;
+ 	os_memset(&gd, 0, sizeof(gd));
+@@ -2331,8 +2350,10 @@ void wpa_sm_notify_assoc(struct wpa_sm *sm, const u8 *bssid)
+ 		sm->tptk_set = 0;
+ 		os_memset(&sm->tptk, 0, sizeof(sm->tptk));
+ 		os_memset(&sm->gtk, 0, sizeof(sm->gtk));
++		os_memset(&sm->gtk_wnm_sleep, 0, sizeof(sm->gtk_wnm_sleep));
+ #ifdef CONFIG_IEEE80211W
+ 		os_memset(&sm->igtk, 0, sizeof(sm->igtk));
++		os_memset(&sm->igtk_wnm_sleep, 0, sizeof(sm->igtk_wnm_sleep));
+ #endif /* CONFIG_IEEE80211W */
+ 	}
+ 
+@@ -2851,8 +2872,10 @@ void wpa_sm_drop_sa(struct wpa_sm *sm)
+ 	os_memset(&sm->ptk, 0, sizeof(sm->ptk));
+ 	os_memset(&sm->tptk, 0, sizeof(sm->tptk));
+ 	os_memset(&sm->gtk, 0, sizeof(sm->gtk));
++	os_memset(&sm->gtk_wnm_sleep, 0, sizeof(sm->gtk_wnm_sleep));
+ #ifdef CONFIG_IEEE80211W
+ 	os_memset(&sm->igtk, 0, sizeof(sm->igtk));
++	os_memset(&sm->igtk_wnm_sleep, 0, sizeof(sm->igtk_wnm_sleep));
+ #endif /* CONFIG_IEEE80211W */
+ #ifdef CONFIG_IEEE80211R
+ 	os_memset(sm->xxkey, 0, sizeof(sm->xxkey));
+@@ -2917,7 +2940,7 @@ int wpa_wnmsleep_install_key(struct wpa_sm *sm, u8 subelem_id, u8 *buf)
+ 
+ 		wpa_hexdump_key(MSG_DEBUG, "Install GTK (WNM SLEEP)",
+ 				gd.gtk, gd.gtk_len);
+-		if (wpa_supplicant_install_gtk(sm, &gd, key_rsc)) {
++		if (wpa_supplicant_install_gtk(sm, &gd, key_rsc, 1)) {
+ 			os_memset(&gd, 0, sizeof(gd));
+ 			wpa_printf(MSG_DEBUG, "Failed to install the GTK in "
+ 				   "WNM mode");
+@@ -2929,7 +2952,7 @@ int wpa_wnmsleep_install_key(struct wpa_sm *sm, u8 subelem_id, u8 *buf)
+ 		const struct wpa_igtk_kde *igtk;
+ 
+ 		igtk = (const struct wpa_igtk_kde *) (buf + 2);
+-		if (wpa_supplicant_install_igtk(sm, igtk) < 0)
++		if (wpa_supplicant_install_igtk(sm, igtk, 1) < 0)
+  			return -1;
+ #endif /* CONFIG_IEEE80211W */
+ 	} else {
+diff --git a/src/rsn_supp/wpa_i.h b/src/rsn_supp/wpa_i.h
+index 27b6123..51753ee 100644
+--- a/src/rsn_supp/wpa_i.h
++++ b/src/rsn_supp/wpa_i.h
+@@ -31,8 +31,10 @@ struct wpa_sm {
+ 	int rx_replay_counter_set;
+ 	u8 request_counter[WPA_REPLAY_COUNTER_LEN];
+ 	struct wpa_gtk gtk;
++	struct wpa_gtk gtk_wnm_sleep;
+ #ifdef CONFIG_IEEE80211W
+ 	struct wpa_igtk igtk;
++	struct wpa_igtk igtk_wnm_sleep;
+ #endif /* CONFIG_IEEE80211W */
+ 
+ 	struct eapol_sm *eapol; /* EAPOL state machine from upper level code */
+-- 
+1.9.1
+

--- a/package/network/services/hostapd/patches/b00-007-Prevent-installation-of-an-all-zero-TK.patch
+++ b/package/network/services/hostapd/patches/b00-007-Prevent-installation-of-an-all-zero-TK.patch
@@ -1,0 +1,61 @@
+From 308490d73b97bc200c27d1baf76b43784ed56055 Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 16:45:06 +0800
+Subject: [PATCH 4/8] Prevent installation of an all-zero TK
+
+Properly track whether a PTK has already been installed to the driver
+and the TK part cleared from memory. This prevents an attacker from
+trying to trick the client into installing an all-zero TK.
+
+This fixes the earlier fix in commit
+ad00d64e7d8827b3cebd665a0ceb08adabf15e1e ('Fix TK configuration to the
+driver in EAPOL-Key 3/4 retry case') which did not take into account
+possibility of an extra message 1/4 showing up between retries of
+message 3/4.
+
+Signed-off-by: Mathy Vanhoef <Mathy.Vanhoef@cs.kuleuven.be>
+---
+ src/common/wpa_common.h | 1 +
+ src/rsn_supp/wpa.c      | 7 +++++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/src/common/wpa_common.h b/src/common/wpa_common.h
+index 542abda..3cec8a6 100644
+--- a/src/common/wpa_common.h
++++ b/src/common/wpa_common.h
+@@ -213,6 +213,7 @@ struct wpa_ptk {
+ 	size_t kck_len;
+ 	size_t kek_len;
+ 	size_t tk_len;
++	int installed; /* 1 if key has already been installed to driver */
+ };
+ 
+ struct wpa_gtk {
+diff --git a/src/rsn_supp/wpa.c b/src/rsn_supp/wpa.c
+index 562b869..8631216 100644
+--- a/src/rsn_supp/wpa.c
++++ b/src/rsn_supp/wpa.c
+@@ -605,6 +605,12 @@ static int wpa_supplicant_install_ptk(struct wpa_sm *sm,
+ 	const u8 *key_rsc;
+ 	u8 null_rsc[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+ 
++	if (sm->ptk.installed) {
++ 		wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
++ 			"WPA: Do not re-install same PTK to the driver");
++ 		return 0;
++	}
++
+ 	wpa_dbg(sm->ctx->msg_ctx, MSG_DEBUG,
+ 		"WPA: Installing PTK to the driver");
+ 
+@@ -643,6 +649,7 @@ static int wpa_supplicant_install_ptk(struct wpa_sm *sm,
+ 
+ 	/* TK is not needed anymore in supplicant */
+ 	os_memset(sm->ptk.tk, 0, WPA_TK_MAX_LEN);
++	sm->ptk.installed = 1;
+ 
+ 	if (sm->wpa_ptk_rekey) {
+ 		eloop_cancel_timeout(wpa_sm_rekey_ptk, sm, NULL);
+-- 
+1.9.1
+

--- a/package/network/services/hostapd/patches/b00-008-Fix-PTK-rekeying-to-generate-a-new-ANonce.patch
+++ b/package/network/services/hostapd/patches/b00-008-Fix-PTK-rekeying-to-generate-a-new-ANonce.patch
@@ -1,0 +1,62 @@
+From 95c2533392225ec86965ebcdd2bb456b4ccfd216 Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 16:50:13 +0800
+Subject: [PATCH 5/8] Fix PTK rekeying to generate a new ANonce
+
+The Authenticator state machine path for PTK rekeying ended up bypassing
+the AUTHENTICATION2 state where a new ANonce is generated when going
+directly to the PTKSTART state since there is no need to try to
+determine the PMK again in such a case. This is far from ideal since the
+new PTK would depend on a new nonce only from the supplicant.
+
+Fix this by generating a new ANonce when moving to the PTKSTART state
+for the purpose of starting new 4-way handshake to rekey PTK.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/ap/wpa_auth.c | 22 +++++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/src/ap/wpa_auth.c b/src/ap/wpa_auth.c
+index 4692ce1..685fd24 100644
+--- a/src/ap/wpa_auth.c
++++ b/src/ap/wpa_auth.c
+@@ -1895,6 +1895,19 @@ SM_STATE(WPA_PTK, AUTHENTICATION2)
+ 	sm->TimeoutCtr = 0;
+ }
+ 
++static int wpa_auth_sm_ptk_update(struct wpa_state_machine *sm)
++{
++	if (random_get_bytes(sm->ANonce, WPA_NONCE_LEN)) {
++		wpa_printf(MSG_ERROR,
++			   "WPA: Failed to get random data for ANonce");
++		sm->Disconnect = TRUE;
++		return -1;
++	}
++	wpa_hexdump(MSG_DEBUG, "WPA: Assign new ANonce", sm->ANonce,
++		    WPA_NONCE_LEN);
++	sm->TimeoutCtr = 0;
++	return 0;
++}
+ 
+ SM_STATE(WPA_PTK, INITPMK)
+ {
+@@ -2417,9 +2430,12 @@ SM_STEP(WPA_PTK)
+ 		SM_ENTER(WPA_PTK, AUTHENTICATION);
+ 	else if (sm->ReAuthenticationRequest)
+ 		SM_ENTER(WPA_PTK, AUTHENTICATION2);
+-	else if (sm->PTKRequest)
+-		SM_ENTER(WPA_PTK, PTKSTART);
+-	else switch (sm->wpa_ptk_state) {
++	else if (sm->PTKRequest) {
++		if (wpa_auth_sm_ptk_update(sm) < 0)
++			SM_ENTER(WPA_PTK, DISCONNECTED);
++		else
++			SM_ENTER(WPA_PTK, PTKSTART);
++	} else switch (sm->wpa_ptk_state) {
+ 	case WPA_PTK_INITIALIZE:
+ 		break;
+ 	case WPA_PTK_DISCONNECT:
+-- 
+1.9.1
+

--- a/package/network/services/hostapd/patches/b00-009-WNM-Ignore-WNM-Sleep-Mode-Response-without-pending-r.patch
+++ b/package/network/services/hostapd/patches/b00-009-WNM-Ignore-WNM-Sleep-Mode-Response-without-pending-r.patch
@@ -1,0 +1,34 @@
+From b9c941d2d0fe01a6d73ec8b3e2fdac6ca2ebe5a4 Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 16:52:23 +0800
+Subject: [PATCH 6/8] WNM: Ignore WNM-Sleep Mode Response without pending
+ request
+
+Commit 03ed0a52393710be6bdae657d1b36efa146520e5 ('WNM: Ignore WNM-Sleep
+Mode Response if WNM-Sleep Mode has not been used') started ignoring the
+response when no WNM-Sleep Mode Request had been used during the
+association. This can be made tighter by clearing the used flag when
+successfully processing a response. This adds an additional layer of
+protection against unexpected retransmissions of the response frame.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ wpa_supplicant/wnm_sta.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/wpa_supplicant/wnm_sta.c b/wpa_supplicant/wnm_sta.c
+index 7d79499..b5c335f 100644
+--- a/wpa_supplicant/wnm_sta.c
++++ b/wpa_supplicant/wnm_sta.c
+@@ -288,6 +288,8 @@ static void ieee802_11_rx_wnmsleep_resp(struct wpa_supplicant *wpa_s,
+ 		return;
+ 	}
+ 
++	wpa_s->wnmsleep_used = 0;
++
+ 	if (wnmsleep_ie->status == WNM_STATUS_SLEEP_ACCEPT ||
+ 	    wnmsleep_ie->status == WNM_STATUS_SLEEP_EXIT_ACCEPT_GTK_UPDATE) {
+ 		wpa_printf(MSG_DEBUG, "Successfully recv WNM-Sleep Response "
+-- 
+1.9.1
+

--- a/package/network/services/hostapd/patches/b00-010-FT-Do-not-allow-multiple-Reassociation-Response-fram.patch
+++ b/package/network/services/hostapd/patches/b00-010-FT-Do-not-allow-multiple-Reassociation-Response-fram.patch
@@ -1,0 +1,83 @@
+From cfa53440d9204b6ef8e0de8f22b054e5993e98d6 Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 16:57:37 +0800
+Subject: [PATCH 7/8] FT: Do not allow multiple Reassociation Response frames
+
+The driver is expected to not report a second association event without
+the station having explicitly request a new association. As such, this
+case should not be reachable. However, since reconfiguring the same
+pairwise or group keys to the driver could result in nonce reuse issues,
+be extra careful here and do an additional state check to avoid this
+even if the local driver ends up somehow accepting an unexpected
+Reassociation Response frame.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/rsn_supp/wpa.c    | 4 ++++
+ src/rsn_supp/wpa_ft.c | 8 ++++++++
+ src/rsn_supp/wpa_i.h  | 1 +
+ 3 files changed, 13 insertions(+)
+
+diff --git a/src/rsn_supp/wpa.c b/src/rsn_supp/wpa.c
+index 8631216..1cd9ee9 100644
+--- a/src/rsn_supp/wpa.c
++++ b/src/rsn_supp/wpa.c
+@@ -2394,6 +2394,10 @@ void wpa_sm_notify_disassoc(struct wpa_sm *sm)
+ 	wpa_tdls_disassoc(sm);
+ #endif /* CONFIG_TDLS */
+ 
++#ifdef CONFIG_IEEE80211R
++	sm->ft_reassoc_completed = 0;
++#endif /* CONFIG_IEEE80211R */
++
+ 	/* Keys are not needed in the WPA state machine anymore */
+ 	wpa_sm_drop_sa(sm);
+ 
+diff --git a/src/rsn_supp/wpa_ft.c b/src/rsn_supp/wpa_ft.c
+index 205793e..d45bb45 100644
+--- a/src/rsn_supp/wpa_ft.c
++++ b/src/rsn_supp/wpa_ft.c
+@@ -153,6 +153,7 @@ static u8 * wpa_ft_gen_req_ies(struct wpa_sm *sm, size_t *len,
+ 	u16 capab;
+ 
+ 	sm->ft_completed = 0;
++	sm->ft_reassoc_completed = 0;
+ 
+ 	buf_len = 2 + sizeof(struct rsn_mdie) + 2 + sizeof(struct rsn_ftie) +
+ 		2 + sm->r0kh_id_len + ric_ies_len + 100;
+@@ -681,6 +682,11 @@ int wpa_ft_validate_reassoc_resp(struct wpa_sm *sm, const u8 *ies,
+ 		return -1;
+ 	}
+ 
++	if (sm->ft_reassoc_completed) {
++		wpa_printf(MSG_DEBUG, "FT: Reassociation has already been completed for this FT protocol instance - ignore unexpected retransmission");
++		return 0;
++	}
++
+ 	if (wpa_ft_parse_ies(ies, ies_len, &parse) < 0) {
+ 		wpa_printf(MSG_DEBUG, "FT: Failed to parse IEs");
+ 		return -1;
+@@ -781,6 +787,8 @@ int wpa_ft_validate_reassoc_resp(struct wpa_sm *sm, const u8 *ies,
+ 		return -1;
+ 	}
+ 
++	sm->ft_reassoc_completed = 1;
++
+ 	if (wpa_ft_process_gtk_subelem(sm, parse.gtk, parse.gtk_len) < 0)
+ 		return -1;
+ 
+diff --git a/src/rsn_supp/wpa_i.h b/src/rsn_supp/wpa_i.h
+index 51753ee..85cc862 100644
+--- a/src/rsn_supp/wpa_i.h
++++ b/src/rsn_supp/wpa_i.h
+@@ -127,6 +127,7 @@ struct wpa_sm {
+ 	size_t r0kh_id_len;
+ 	u8 r1kh_id[FT_R1KH_ID_LEN];
+ 	int ft_completed;
++	int ft_reassoc_completed;
+ 	int over_the_ds_in_progress;
+ 	u8 target_ap[ETH_ALEN]; /* over-the-DS target AP */
+ 	int set_ptk_after_assoc;
+-- 
+1.9.1
+

--- a/package/network/services/hostapd/patches/b00-011-TDLS-Reject-TPK-TK-reconfiguration.patch
+++ b/package/network/services/hostapd/patches/b00-011-TDLS-Reject-TPK-TK-reconfiguration.patch
@@ -1,0 +1,134 @@
+From 2121b68427c71785fed15cd60a4643bc5a3794c3 Mon Sep 17 00:00:00 2001
+From: Miaoqing Pan <miaoqing@codeaurora.org>
+Date: Wed, 18 Oct 2017 17:17:02 +0800
+Subject: [PATCH] TDLS: Reject TPK-TK reconfiguration
+
+Do not try to reconfigure the same TPK-TK to the driver after it has
+been successfully configured. This is an explicit check to avoid issues
+related to resetting the TX/RX packet number. There was already a check
+for this for TPK M2 (retries of that message are ignored completely), so
+that behavior does not get modified.
+
+For TPK M3, the TPK-TK could have been reconfigured, but that was
+followed by immediate teardown of the link due to an issue in updating
+the STA entry. Furthermore, for TDLS with any real security (i.e.,
+ignoring open/WEP), the TPK message exchange is protected on the AP path
+and simple replay attacks are not feasible.
+
+As an additional corner case, make sure the local nonce gets updated if
+the peer uses a very unlikely "random nonce" of all zeros.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/rsn_supp/tdls.c | 40 ++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 38 insertions(+), 2 deletions(-)
+
+diff --git a/src/rsn_supp/tdls.c b/src/rsn_supp/tdls.c
+index 722c20a..35d14ce 100644
+--- a/src/rsn_supp/tdls.c
++++ b/src/rsn_supp/tdls.c
+@@ -112,6 +112,7 @@ struct wpa_tdls_peer {
+ 		u8 tk[16]; /* TPK-TK; assuming only CCMP will be used */
+ 	} tpk;
+ 	int tpk_set;
++	int tk_set; /* TPK-TK configured to the driver */
+ 	int tpk_success;
+ 	int tpk_in_progress;
+ 
+@@ -192,6 +193,20 @@ static int wpa_tdls_set_key(struct wpa_sm *sm, struct wpa_tdls_peer *peer)
+ 	u8 rsc[6];
+ 	enum wpa_alg alg;
+ 
++	if (peer->tk_set) {
++		/*
++		 * This same TPK-TK has already been configured to the driver
++		 * and this new configuration attempt (likely due to an
++		 * unexpected retransmitted frame) would result in clearing
++		 * the TX/RX sequence number which can break security, so must
++		 * not allow that to happen.
++		 */
++		wpa_printf(MSG_INFO, "TDLS: TPK-TK for the peer " MACSTR
++			   " has already been configured to the driver - do not reconfigure",
++			   MAC2STR(peer->addr));
++		return -1;
++	}
++
+ 	os_memset(rsc, 0, 6);
+ 
+ 	switch (peer->cipher) {
+@@ -209,12 +224,18 @@ static int wpa_tdls_set_key(struct wpa_sm *sm, struct wpa_tdls_peer *peer)
+ 		return -1;
+ 	}
+ 
++	wpa_printf(MSG_DEBUG, "TDLS: Configure pairwise key for peer " MACSTR,
++		   MAC2STR(peer->addr));
++
+ 	if (wpa_sm_set_key(sm, alg, peer->addr, -1, 1,
+ 			   rsc, sizeof(rsc), peer->tpk.tk, key_len) < 0) {
+ 		wpa_printf(MSG_WARNING, "TDLS: Failed to set TPK to the "
+ 			   "driver");
+ 		return -1;
+ 	}
++
++	peer->tk_set = 1;
++
+ 	return 0;
+ }
+ 
+@@ -690,7 +711,7 @@ static void wpa_tdls_peer_clear(struct wpa_sm *sm, struct wpa_tdls_peer *peer)
+ 	peer->cipher = 0;
+ 	peer->qos_info = 0;
+ 	peer->wmm_capable = 0;
+-	peer->tpk_set = peer->tpk_success = 0;
++	peer->tk_set = peer->tpk_set = peer->tpk_success = 0;
+ 	peer->chan_switch_enabled = 0;
+ 	os_memset(&peer->tpk, 0, sizeof(peer->tpk));
+ 	os_memset(peer->inonce, 0, WPA_NONCE_LEN);
+@@ -1153,6 +1174,8 @@ skip_rsnie:
+ 		wpa_tdls_peer_free(sm, peer);
+ 		return -1;
+ 	}
++
++	peer->tk_set = 0; /* A new nonce results in a new TK */
+ 	wpa_hexdump(MSG_DEBUG, "TDLS: Initiator Nonce for TPK handshake",
+ 		    peer->inonce, WPA_NONCE_LEN);
+ 	os_memcpy(ftie->Snonce, peer->inonce, WPA_NONCE_LEN);
+@@ -1744,6 +1767,17 @@ static int wpa_tdls_addset_peer(struct wpa_sm *sm, struct wpa_tdls_peer *peer,
+ 				       peer->supp_oper_classes_len);
+ }
+ 
++static int tdls_nonce_set(const u8 *nonce)
++{
++	int i;
++
++	for (i = 0; i < WPA_NONCE_LEN; i++) {
++		if (nonce[i])
++			return 1;
++	}
++
++	return 0;
++}
+ 
+ static int wpa_tdls_process_tpk_m1(struct wpa_sm *sm, const u8 *src_addr,
+ 				   const u8 *buf, size_t len)
+@@ -1998,7 +2032,8 @@ skip_rsn:
+ 	peer->rsnie_i_len = kde.rsn_ie_len;
+ 	peer->cipher = cipher;
+ 
+-	if (os_memcmp(peer->inonce, ftie->Snonce, WPA_NONCE_LEN) != 0) {
++	if (os_memcmp(peer->inonce, ftie->Snonce, WPA_NONCE_LEN) != 0 ||
++	    !tdls_nonce_set(peer->inonce)) {
+ 		/*
+ 		 * There is no point in updating the RNonce for every obtained
+ 		 * TPK M1 frame (e.g., retransmission due to timeout) with the
+@@ -2014,6 +2049,7 @@ skip_rsn:
+ 				"TDLS: Failed to get random data for responder nonce");
+ 			goto error;
+ 		}
++		peer->tk_set = 0; /* A new nonce results in a new TK */
+ 	}
+ 
+ #if 0
+-- 
+1.9.1
+


### PR DESCRIPTION
当前版本：caf_AU_LINUX_QSDK_RELEASE_DATE_IOE4531_3.0.R1_TARGET_ALL.3.0.490.220.xml
更新版本：caf_AU_LINUX_QSDK_RELEASE_DATE_IOE4531_3.0.R1_TARGET_ALL.3.0.490.256.xml
通过beyondcompare对比2个版本，差异只新增了：
qsdk\package\network\services\hostapd\patches\b00-*