### PR TITLE
add config option identifier && loglevel

### DIFF
--- a/qca/feeds/leedarson/chron/files/chron.config
+++ b/qca/feeds/leedarson/chron/files/chron.config
@@ -1,4 +1,3 @@
 config chron 'chron'
-	option abc 'scheduled'
-	option xyz 'daemon to execute scheduled commands'
-	option delay 100
+	option identifier 'chron'
+	option loglevel 5

--- a/qca/feeds/leedarson/chron/files/chron.init
+++ b/qca/feeds/leedarson/chron/files/chron.init
@@ -6,10 +6,23 @@ START=99
 STOP=13
 PROG=`which chron`
 
+validate_chron_section() {
+	uci_validate_section chron chron "${1}" \
+		'identifier:string' \
+		'loglevel:uinteger' 
+}
+
 start_service() 
-{	
+{
+	local identifier loglevel
+	
+	validate_chron_section chron || {
+		echo "validation failed"
+		return 1
+	}
+	
 	procd_open_instance
-	procd_set_param command "$PROG"
+	procd_set_param command "$PROG" -i "$identifier" -l "$loglevel"
 	procd_set_param respawn
 	procd_close_instance
 }
@@ -24,4 +37,3 @@ reload_service()
 	stop
 	start
 }
-


### PR DESCRIPTION
为chron添加日志控制方案
1. 在配置文件/etc/config/chron中，添加参数identifier，loglevel 
2. 在启动脚本/etc/init.d/chron中，启动程序时，附带参数启动. 如/usr/bin/chron -i chron -l 4
